### PR TITLE
Make the config constants public so that they can be reused in Quarkus

### DIFF
--- a/src/main/java/org/infinispan/quarkus/hibernate/cache/QuarkusInfinispanRegionFactory.java
+++ b/src/main/java/org/infinispan/quarkus/hibernate/cache/QuarkusInfinispanRegionFactory.java
@@ -21,9 +21,9 @@ public final class QuarkusInfinispanRegionFactory implements RegionFactory {
 
     private static final Logger log = Logger.getLogger(QuarkusInfinispanRegionFactory.class);
 
-    private static final String PREFIX = "hibernate.cache.";
-    private static final String OBJECT_COUNT_SUFFIX = ".memory.object-count";
-    private static final String MAX_IDLE_SUFFIX = ".expiration.max-idle";
+    public static final String PREFIX = "hibernate.cache.";
+    public static final String OBJECT_COUNT_SUFFIX = ".memory.object-count";
+    public static final String MAX_IDLE_SUFFIX = ".expiration.max-idle";
 
     private final Map<String, InternalCache> caches = new HashMap<>();
 


### PR DESCRIPTION
@Sanne could you take a look at this (micro) PR?

The idea is to reuse the constants in Quarkus when we push the configuration.