### PR TITLE
Relicense PutFromLoadValidator.java to ASL 2

### DIFF
--- a/src/main/java/org/infinispan/quarkus/hibernate/cache/PutFromLoadValidator.java
+++ b/src/main/java/org/infinispan/quarkus/hibernate/cache/PutFromLoadValidator.java
@@ -1,9 +1,3 @@
-/*
- * Hibernate, Relational Persistence for Idiomatic Java
- *
- * License: GNU Lesser General Public License (LGPL), version 2.1 or later.
- * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
- */
 package org.infinispan.quarkus.hibernate.cache;
 
 import com.github.benmanes.caffeine.cache.Cache;


### PR DESCRIPTION
Fixes #9 

As far as I can see, this file is the result of contributions to Hibernate ORM, then Infinispan (after the file moved there).

For Hibernate ORM, authors either worked for Red Hat at the time, or explicitly agreed to relicensing their contributions to Hibernate ORM to ASL 2:

* Galder Zamarreño
* Radim Vansa
* Vlad Mihalcea
* Steve Ebersole
* Strong Liu
* John Verhaeg

For Infinispan, authors contributed to an ASL2 project, so they obviously agree with the ASL2 license.

See here for the complete history of this file:

https://github.com/hibernate/hibernate-orm/commits/abc165eaba9a3de403b09354661afa4cb8b43404/cache-infinispan/src/test/java/org/hibernate/test/cache/infinispan/functional/cluster/AbstractDualNodeTestCase.java?browsing_rename_history=true&new_path=hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/access/PutFromLoadValidator.java&original_branch=a21706bf02c0e9f61cbe522f407fd0d35e621f57 https://github.com/hibernate/hibernate-orm/commits/8beaccc7eb33325606d8ef5df928c4782cd042e9/cache-infinispan/src/main/java/org/hibernate/cache/infinispan/access/PutFromLoadValidator.java?browsing_rename_history=true&new_path=hibernate-infinispan/src/main/java/org/hibernate/cache/infinispan/access/PutFromLoadValidator.java&original_branch=a21706bf02c0e9f61cbe522f407fd0d35e621f57 https://github.com/infinispan/infinispan/commits/d99a60ab2dea20de5a9227e525bee2ef31aa917d/src/main/java/org/hibernate/cache/infinispan/access/PutFromLoadValidator.java?browsing_rename_history=true&new_path=hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/PutFromLoadValidator.java&original_branch=main https://github.com/infinispan/infinispan/commits/6984ca2000f4312daa507070e9882ef9401a7063/hibernate-cache/src/main/java/org/hibernate/cache/infinispan/access/PutFromLoadValidator.java?browsing_rename_history=true&new_path=hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/PutFromLoadValidator.java&original_branch=main https://github.com/infinispan/infinispan/commits/231291d79d4c1a615a1000c7870f6600c8eeab19/hibernate-cache/src/main/java/org/infinispan/hibernate/cache/access/PutFromLoadValidator.java?browsing_rename_history=true&new_path=hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/PutFromLoadValidator.java&original_branch=main https://github.com/infinispan/infinispan/commits/main/hibernate/cache-commons/src/main/java/org/infinispan/hibernate/cache/commons/access/PutFromLoadValidator.java

@tristantarrant you might want to relicense this file in Infinispan too?