### PR TITLE
Use a unique groupId (and bump version)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <artifactId>quarkus-local-cache</artifactId>
     <name>Local-only Hibernate Cache for Quarkus</name>
     <description>Local-only Hibernate Cache optimized for Quarkus</description>
-    <version>0.3.2-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
     <inceptionYear>2019</inceptionYear>
     <url>https://github.com/hibernate/quarkus-local-cache</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.hibernate</groupId>
+    <groupId>org.hibernate.local-cache</groupId>
     <artifactId>quarkus-local-cache</artifactId>
     <name>Local-only Hibernate Cache for Quarkus</name>
     <description>Local-only Hibernate Cache optimized for Quarkus</description>


### PR DESCRIPTION
Because every project should have its own, and using org.hibernate here
is forcing us to handle that weirdness in Quarkus' dependabot rules.

I suppose we should also think about moving this to the Quarkus org, because, you know, it's really a Quarkus project, but that can wait.
This, at least, can be done right now, while to Quarkus would imply involving more people and changing the release process significantly.