### PR TITLE
Prevent Dependabot from upgrading Hibernate beyond patch versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "org.hibernate*"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
     groups:
       build-dependencies:
         patterns:


### PR DESCRIPTION
## Summary

- Adds an `ignore` rule to the Dependabot configuration that blocks major and minor version upgrades for `org.hibernate*` dependencies
- Patch (micro) version updates are still allowed, so security and bug fixes continue to flow in automatically

## Context

Hibernate major/minor upgrades can introduce breaking API changes or behavioral differences that require careful manual review and testing. Limiting Dependabot to patch-only updates prevents unexpected breakage while still keeping dependencies current for bug fixes.

## Test plan

- [ ] Verify that Dependabot no longer opens PRs for Hibernate minor/major bumps
- [ ] Verify that Dependabot still proposes Hibernate patch version updates